### PR TITLE
DUI: validate image size before attempting to set as icon [2/2]

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="info_pref_note_title">Note</string>
     <string name="smartbar_interface">SmartBar</string>
     <string name="icon_pack_picker_dialog_title">Icon packs</string>
+    <string name="image_exceeds_max_allowed_size">Image must not exceed 512x512</string>
     <string name="invalid_icon_from_uri">Unable to load image from content provider</string>
     <string name="picker_activities">Activities</string>
     <string name="select_custom_app_title">Select custom app</string>

--- a/src/com/dirtyunicorns/dutweaks/IconPickHelper.java
+++ b/src/com/dirtyunicorns/dutweaks/IconPickHelper.java
@@ -32,6 +32,7 @@ import android.os.Environment;
 import android.util.Log;
 import android.widget.Toast;
 
+import com.android.internal.utils.du.DUActionUtils;
 import com.android.settings.R;
 
 public class IconPickHelper {
@@ -69,37 +70,45 @@ public class IconPickHelper {
                 case REQUEST_CODE_GALLERY:
                     Bitmap b = null;
                     try {
-                        b = ImageHelper.getBitmapFromUri(mParent, data.getData());
+                        if (DUActionUtils.isBitmapAllowedSize(mParent, data.getData(),
+                                DUActionUtils.DUI_ICON_MAX_WIDTH, DUActionUtils.DUI_ICON_MAX_HEIGHT)) {
+                            b = ImageHelper.getBitmapFromUri(mParent, data.getData());
+                            if (b != null) {
+                                File dir = new File(Environment.getExternalStorageDirectory()
+                                        + File.separator
+                                        + "dui_icons");
+                                dir.mkdirs();
+                                String fileName = "dui_icons_"
+                                        + String.valueOf(System.currentTimeMillis());
+                                Uri newUri = ImageHelper.addBitmapToStorage(dir, fileName, b);
+                                if (newUri == null) {
+                                    Toast.makeText(mParent,
+                                            mParent.getString(R.string.invalid_icon_from_uri),
+                                            Toast.LENGTH_SHORT)
+                                            .show();
+                                    mListener.imagePicked(null);
+                                } else {
+                                    mListener.imagePicked(newUri);
+                                }
+                            } else {
+                                Toast.makeText(mParent, mParent.getString(R.string.invalid_icon_from_uri),
+                                        Toast.LENGTH_SHORT)
+                                        .show();
+                                mListener.imagePicked(null);
+                            }
+                        } else {
+                            Toast.makeText(mParent, mParent.getString(R.string.image_exceeds_max_allowed_size),
+                                    Toast.LENGTH_SHORT)
+                                    .show();
+                            mListener.imagePicked(null);
+                        }
                     } catch (Exception e) {
                         Toast.makeText(mParent, mParent.getString(R.string.invalid_icon_from_uri),
                                 Toast.LENGTH_SHORT)
                                 .show();
                         mListener.imagePicked(null);
                     }
-                    if (b != null) {
-                        File dir = new File(Environment.getExternalStorageDirectory()
-                                + File.separator
-                                + "dui_icons");
-                        dir.mkdirs();
-                        String fileName = "dui_icons_"
-                                + String.valueOf(System.currentTimeMillis());
-                        Uri newUri = ImageHelper.addBitmapToStorage(dir, fileName, b);
-                        if (newUri == null) {
-                            Toast.makeText(mParent,
-                                    mParent.getString(R.string.invalid_icon_from_uri),
-                                    Toast.LENGTH_SHORT)
-                                    .show();
-                            mListener.imagePicked(null);
-                        } else {
-                            mListener.imagePicked(newUri);
-                        }
-                    } else {
-                        Toast.makeText(mParent, mParent.getString(R.string.invalid_icon_from_uri),
-                                Toast.LENGTH_SHORT)
-                                .show();
-                        mListener.imagePicked(null);
-                    }
-                    break;
+                break;
             }
         }
     }

--- a/src/com/dirtyunicorns/dutweaks/IconPickerGallery.java
+++ b/src/com/dirtyunicorns/dutweaks/IconPickerGallery.java
@@ -19,6 +19,7 @@ package com.dirtyunicorns.dutweaks;
 
 import java.io.File;
 
+import com.android.internal.utils.du.DUActionUtils;
 import com.android.internal.utils.du.ImageHelper;
 
 import android.app.Activity;
@@ -56,35 +57,43 @@ public class IconPickerGallery extends Activity {
         if (resultCode == Activity.RESULT_OK && requestCode == 69) {
             Bitmap b = null;
             try {
-                b = ImageHelper.getBitmapFromUri(this, data.getData());
-            } catch (Exception e) {
-                Toast.makeText(this, getString(R.string.invalid_icon_from_uri), Toast.LENGTH_SHORT)
-                        .show();
-                sendCancelResultAndFinish();
-            }
-            if (b != null) {
-                File dir = new File(Environment.getExternalStorageDirectory() + File.separator
-                        + "dui_icons");
-                dir.mkdirs();
-                String fileName = "dui_icons_"
-                        + String.valueOf(System.currentTimeMillis());
-                ;
-                Uri newUri = ImageHelper.addBitmapToStorage(dir, fileName, b);
-                if (newUri == null) {
-                    Toast.makeText(this, getString(R.string.invalid_icon_from_uri),
+                if (DUActionUtils.isBitmapAllowedSize(this, data.getData(),
+                        DUActionUtils.DUI_ICON_MAX_WIDTH, DUActionUtils.DUI_ICON_MAX_HEIGHT)) {
+                    b = ImageHelper.getBitmapFromUri(this, data.getData());
+                    if (b != null) {
+                        File dir = new File(Environment.getExternalStorageDirectory() + File.separator
+                                + "dui_icons");
+                        dir.mkdirs();
+                        String fileName = "dui_icons_"
+                                + String.valueOf(System.currentTimeMillis());
+                        ;
+                        Uri newUri = ImageHelper.addBitmapToStorage(dir, fileName, b);
+                        if (newUri == null) {
+                            Toast.makeText(this, getString(R.string.invalid_icon_from_uri),
+                                    Toast.LENGTH_SHORT)
+                                    .show();
+                            sendCancelResultAndFinish();
+                        } else {
+                            Intent resultIntent = new Intent();
+                            resultIntent.setAction(INTENT_GALLERY_PICKER);
+                            resultIntent.putExtra("result", Activity.RESULT_OK);
+                            resultIntent.putExtra("uri", newUri.toString());
+                            sendBroadcastAsUser(resultIntent, UserHandle.CURRENT);
+                            setResult(RESULT_OK, resultIntent);
+                            finish();
+                        }
+                    } else {
+                        Toast.makeText(this, getString(R.string.invalid_icon_from_uri), Toast.LENGTH_SHORT)
+                                .show();
+                        sendCancelResultAndFinish();
+                    }
+                } else {
+                    Toast.makeText(this, getString(R.string.image_exceeds_max_allowed_size),
                             Toast.LENGTH_SHORT)
                             .show();
                     sendCancelResultAndFinish();
-                } else {
-                    Intent resultIntent = new Intent();
-                    resultIntent.setAction(INTENT_GALLERY_PICKER);
-                    resultIntent.putExtra("result", Activity.RESULT_OK);
-                    resultIntent.putExtra("uri", newUri.toString());
-                    sendBroadcastAsUser(resultIntent, UserHandle.CURRENT);
-                    setResult(RESULT_OK, resultIntent);
-                    finish();
                 }
-            } else {
+            } catch (Exception e) {
                 Toast.makeText(this, getString(R.string.invalid_icon_from_uri), Toast.LENGTH_SHORT)
                         .show();
                 sendCancelResultAndFinish();


### PR DESCRIPTION
Validate all custom icon image sizes before we move on to further
processing. Set a max allowed image size of 512x512. This should
act as somewhat of a "sanity filter" for the users that try to set
wallpapers as DUI icons ;D

ezio: set the limit to 512 (added bitmapfactory sample
scaling in the 1/2 part so we still have small high quality bitmaps
without system performances loss)
fixed fling custom logo img logic so the img is not saved on sdcard
if size>512

Change-Id: I65f31c48e868873eca63695ca15a2495e638d6ee